### PR TITLE
fix for wrong pattern match.

### DIFF
--- a/contrib/opencv/opencv.sh
+++ b/contrib/opencv/opencv.sh
@@ -3,7 +3,7 @@ type wget > /dev/null 2>&1 || { echo >&2 "wget command not found. Aborting."; ex
 type unzip > /dev/null 2>&1 || { echo >&2 "unzip command not found. Aborting."; exit 1; }
 type make > /dev/null 2>&1 || { echo >&2 "make command not found. Aborting."; exit 1; }
 
-version="$(wget -q -O - http://sourceforge.net/projects/opencvlibrary/files/opencv-unix | egrep -m1 -o '\"[0-9](\.[0-9]+\-*[a-z0-9]*)+' | cut -c2-)"
+version="$(wget -q -O - http://sourceforge.net/projects/opencvlibrary/files/opencv-unix | egrep -m1 -o 'opencv-unix/[0-9](\.[0-9]+\-*[a-z0-9]*)+' | cut -c13-)"
 echo "Installing OpenCV" $version
 echo "Installing Dependencies"
 sudo apt-get update


### PR DESCRIPTION
Was matching 1.1 due to just looking for "0-9.0-9, this way looking for opencv-unix/ as a prefix it will find the matching version structure properly.